### PR TITLE
feat: Store software upgrade plan and refresh data at upgrade height

### DIFF
--- a/cmd/parse/staking/validators.go
+++ b/cmd/parse/staking/validators.go
@@ -41,18 +41,9 @@ func validatorsCmd(parseConfig *parsecmdtypes.Config) *cobra.Command {
 				return fmt.Errorf("error while getting latest block height: %s", err)
 			}
 
-			// Get all validators
-			validators, err := sources.StakingSource.GetValidatorsWithStatus(height, "")
+			err = stakingModule.RefreshAllValidatorInfos(height)
 			if err != nil {
-				return fmt.Errorf("error while getting validators: %s", err)
-			}
-
-			// Refresh each validator
-			for _, validator := range validators {
-				err = stakingModule.RefreshValidatorInfos(height, validator.OperatorAddress)
-				if err != nil {
-					return fmt.Errorf("error while refreshing validator: %s", err)
-				}
+				return fmt.Errorf("error while refreshing all validators infos: %s", err)
 			}
 
 			return nil

--- a/database/gov.go
+++ b/database/gov.go
@@ -7,6 +7,7 @@ import (
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/forbole/bdjuno/v3/types"
@@ -392,6 +393,65 @@ WHERE proposal_validator_status_snapshot.height <= excluded.height`
 	_, err := db.Sql.Exec(stmt, args...)
 	if err != nil {
 		return fmt.Errorf("error while storing proposal validator statuses snapshot: %s", err)
+	}
+
+	return nil
+}
+
+// SaveSoftwareUpgradePlan allows to save the given software upgrade plan with its proposal id
+func (db *Db) SaveSoftwareUpgradePlan(proposalID uint64, plan upgradetypes.Plan, height int64) error {
+
+	stmt := `
+INSERT INTO software_upgrade_plan(proposal_id, plan_name, upgrade_height, info, height) 
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (proposal_id) DO UPDATE SET
+	plan_name = excluded.plan_name, 
+	upgrade_height = excluded.upgrade_height, 
+	info = excluded.info, 
+	height = excluded.height 
+WHERE software_upgrade_plan.height <= excluded.height`
+
+	_, err := db.Sql.Exec(stmt,
+		proposalID, plan.Name, plan.Height, plan.Info, height)
+	if err != nil {
+		return fmt.Errorf("error while storing software upgrade plan: %s", err)
+	}
+
+	return nil
+}
+
+// DeleteSoftwareUpgradePlan allows to delete a SoftwareUpgradePlan with proposal ID
+func (db *Db) DeleteSoftwareUpgradePlan(proposalID uint64) error {
+	stmt := `DELETE FROM software_upgrade_plan WHERE proposal_id = $1`
+
+	_, err := db.Sql.Exec(stmt, proposalID)
+	if err != nil {
+		return fmt.Errorf("error while deleting software upgrade plan: %s", err)
+	}
+
+	return nil
+}
+
+// CheckSoftwareUpgradePlan returns true if an upgrade is scheduled at the given height
+func (db *Db) CheckSoftwareUpgradePlan(upgradeHeight int64) (bool, error) {
+	var exist bool
+
+	stmt := `SELECT EXISTS (SELECT 1 FROM software_upgrade_plan WHERE upgrade_height=$1)`
+	err := db.Sql.QueryRow(stmt, upgradeHeight).Scan(&exist)
+	if err != nil {
+		return exist, fmt.Errorf("error while checking software upgrade plan existence: %s", err)
+	}
+
+	return exist, nil
+}
+
+// TruncateSoftwareUpgradePlan delete software upgrade plans once the upgrade height passed
+func (db *Db) TruncateSoftwareUpgradePlan(height int64) error {
+	stmt := `DELETE FROM software_upgrade_plan WHERE upgrade_height <= $1`
+
+	_, err := db.Sql.Exec(stmt, height)
+	if err != nil {
+		return fmt.Errorf("error while deleting software upgrade plan: %s", err)
 	}
 
 	return nil

--- a/database/schema/12-upgrade.sql
+++ b/database/schema/12-upgrade.sql
@@ -1,0 +1,10 @@
+CREATE TABLE software_upgrade_plan
+(
+    proposal_id     INTEGER REFERENCES proposal (id) UNIQUE,
+    plan_name       TEXT        NOT NULL,
+    upgrade_height  BIGINT      NOT NULL,
+    info            TEXT        NOT NULL,
+    height          BIGINT      NOT NULL
+);
+CREATE INDEX software_upgrade_plan_proposal_id_index ON software_upgrade_plan (proposal_id);
+CREATE INDEX software_upgrade_plan_height_index ON software_upgrade_plan (height);

--- a/database/types/upgrade.go
+++ b/database/types/upgrade.go
@@ -1,0 +1,21 @@
+package types
+
+type SoftwareUpgradePlanRow struct {
+	ProposalID    uint64 `db:"proposal_id"`
+	PlanName      string `db:"plan_name"`
+	UpgradeHeight int64  `db:"upgrade_height"`
+	Info          string `db:"info"`
+	Height        int64  `db:"height"`
+}
+
+func NewSoftwareUpgradePlanRow(
+	proposalID uint64, planName string, upgradeHeight int64, info string, height int64,
+) SoftwareUpgradePlanRow {
+	return SoftwareUpgradePlanRow{
+		ProposalID:    proposalID,
+		PlanName:      planName,
+		UpgradeHeight: upgradeHeight,
+		Info:          info,
+		Height:        height,
+	}
+}

--- a/hasura/metadata/databases/bdjuno/tables/public_software_upgrade_plan.yaml
+++ b/hasura/metadata/databases/bdjuno/tables/public_software_upgrade_plan.yaml
@@ -1,0 +1,18 @@
+table:
+  name: software_upgrade_plan
+  schema: public
+object_relationships:
+- name: proposal
+  using:
+    foreign_key_constraint_on: proposal_id
+select_permissions:
+- permission:
+    allow_aggregations: true
+    columns:
+    - proposal_id
+    - plan_name
+    - upgrade_height
+    - info
+    - height
+    filter: {}
+  role: anonymous

--- a/hasura/metadata/databases/bdjuno/tables/tables.yaml
+++ b/hasura/metadata/databases/bdjuno/tables/tables.yaml
@@ -23,6 +23,7 @@
 - "!include public_proposal_validator_status_snapshot.yaml"
 - "!include public_proposal_vote.yaml"
 - "!include public_slashing_params.yaml"
+- "!include public_software_upgrade_plan.yaml"
 - "!include public_staking_params.yaml"
 - "!include public_staking_pool.yaml"
 - "!include public_supply.yaml"

--- a/modules/gov/handle_msg.go
+++ b/modules/gov/handle_msg.go
@@ -55,13 +55,6 @@ func (m *Module) handleMsgSubmitProposal(tx *juno.Tx, index int, msg *govtypes.M
 		return fmt.Errorf("error while getting proposal: %s", err)
 	}
 
-	// Unpack the content
-	var content govtypes.Content
-	err = m.cdc.UnpackAny(proposal.Content, &content)
-	if err != nil {
-		return fmt.Errorf("error while unpacking proposal content: %s", err)
-	}
-
 	// Store the proposal
 	proposalObj := types.NewProposal(
 		proposal.ProposalId,

--- a/modules/gov/utils_proposal.go
+++ b/modules/gov/utils_proposal.go
@@ -8,6 +8,7 @@ import (
 	proposaltypes "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
 
 	"google.golang.org/grpc/codes"
@@ -31,11 +32,6 @@ func (m *Module) UpdateProposal(height int64, id uint64) error {
 		return fmt.Errorf("error while getting proposal: %s", err)
 	}
 
-	err = m.handleParamChangeProposal(height, proposal)
-	if err != nil {
-		return fmt.Errorf("error while updating params from ParamChangeProposal: %s", err)
-	}
-
 	err = m.updateProposalStatus(proposal)
 	if err != nil {
 		return fmt.Errorf("error while updating proposal status: %s", err)
@@ -50,6 +46,12 @@ func (m *Module) UpdateProposal(height int64, id uint64) error {
 	if err != nil {
 		return fmt.Errorf("error while updating account: %s", err)
 	}
+
+	err = m.handlePassedProposal(proposal, height)
+	if err != nil {
+		return fmt.Errorf("error while handling passed proposals: %s", err)
+	}
+
 	return nil
 }
 
@@ -86,23 +88,7 @@ func (m *Module) updateDeletedProposalStatus(id uint64) error {
 }
 
 // handleParamChangeProposal updates params to the corresponding modules if a ParamChangeProposal has passed
-func (m *Module) handleParamChangeProposal(height int64, proposal govtypes.Proposal) error {
-	if proposal.Status != govtypes.StatusPassed {
-		// If the status of ParamChangeProposal is not passed, do nothing
-		return nil
-	}
-
-	var content govtypes.Content
-	err := m.db.EncodingConfig.Marshaler.UnpackAny(proposal.Content, &content)
-	if err != nil {
-		return fmt.Errorf("error while handling ParamChangeProposal: %s", err)
-	}
-
-	paramChangeProposal, ok := content.(*proposaltypes.ParameterChangeProposal)
-	if !ok {
-		return nil
-	}
-
+func (m *Module) handleParamChangeProposal(height int64, paramChangeProposal *proposaltypes.ParameterChangeProposal) (err error) {
 	for _, change := range paramChangeProposal.Changes {
 		// Update the params for corresponding modules
 		switch change.Subspace {
@@ -278,4 +264,42 @@ func findStatus(consAddr string, statuses []types.ValidatorStatus) (types.Valida
 		}
 	}
 	return types.ValidatorStatus{}, fmt.Errorf("cannot find status for validator with consensus address %s", consAddr)
+}
+
+func (m *Module) handlePassedProposal(proposal govtypes.Proposal, height int64) error {
+	if proposal.Status != govtypes.StatusPassed {
+		// If proposal status is not passed, do nothing
+		return nil
+	}
+
+	// Unpack proposal
+	var content govtypes.Content
+	err := m.db.EncodingConfig.Marshaler.UnpackAny(proposal.Content, &content)
+	if err != nil {
+		return fmt.Errorf("error while handling ParamChangeProposal: %s", err)
+	}
+
+	switch p := content.(type) {
+	case *proposaltypes.ParameterChangeProposal:
+		// Update params while ParameterChangeProposal passed
+		err = m.handleParamChangeProposal(height, p)
+		if err != nil {
+			return fmt.Errorf("error while updating params from ParamChangeProposal: %s", err)
+		}
+
+	case *upgradetypes.SoftwareUpgradeProposal:
+		// Store software upgrade plan while SoftwareUpgradeProposal passed
+		err = m.db.SaveSoftwareUpgradePlan(proposal.ProposalId, p.Plan, height)
+		if err != nil {
+			return fmt.Errorf("error while storing software upgrade plan: %s", err)
+		}
+
+	case *upgradetypes.CancelSoftwareUpgradeProposal:
+		// Delete software upgrade plan while CancelSoftwareUpgradeProposal passed
+		err = m.db.DeleteSoftwareUpgradePlan(proposal.ProposalId)
+		if err != nil {
+			return fmt.Errorf("error while deleting software upgrade plan: %s", err)
+		}
+	}
+	return nil
 }

--- a/modules/registrar.go
+++ b/modules/registrar.go
@@ -30,6 +30,7 @@ import (
 	"github.com/forbole/bdjuno/v3/modules/modules"
 	"github.com/forbole/bdjuno/v3/modules/pricefeed"
 	"github.com/forbole/bdjuno/v3/modules/staking"
+	"github.com/forbole/bdjuno/v3/modules/upgrade"
 )
 
 // UniqueAddressesParser returns a wrapper around the given parser that removes all duplicated addresses
@@ -81,6 +82,7 @@ func (r *Registrar) BuildModules(ctx registrar.Context) jmodules.Modules {
 	slashingModule := slashing.NewModule(sources.SlashingSource, cdc, db)
 	stakingModule := staking.NewModule(sources.StakingSource, cdc, db)
 	govModule := gov.NewModule(sources.GovSource, authModule, distrModule, mintModule, slashingModule, stakingModule, cdc, db)
+	upgradeModule := upgrade.NewModule(db, stakingModule)
 
 	return []jmodules.Module{
 		messages.NewModule(r.parser, cdc, ctx.Database),
@@ -100,5 +102,6 @@ func (r *Registrar) BuildModules(ctx registrar.Context) jmodules.Modules {
 		pricefeed.NewModule(ctx.JunoConfig, cdc, db),
 		slashingModule,
 		stakingModule,
+		upgradeModule,
 	}
 }

--- a/modules/staking/utils_validators.go
+++ b/modules/staking/utils_validators.go
@@ -80,6 +80,25 @@ func (m *Module) convertValidatorDescription(
 
 // --------------------------------------------------------------------------------------------------------------------
 
+// RefreshAllValidatorInfos refreshes the info of all the validators at the given height
+func (m *Module) RefreshAllValidatorInfos(height int64) error {
+	// Get all validators
+	validators, err := m.source.GetValidatorsWithStatus(height, "")
+	if err != nil {
+		return fmt.Errorf("error while getting validators: %s", err)
+	}
+
+	// Refresh each validator
+	for _, validator := range validators {
+		err = m.RefreshValidatorInfos(height, validator.OperatorAddress)
+		if err != nil {
+			return fmt.Errorf("error while refreshing validator: %s", err)
+		}
+	}
+
+	return nil
+}
+
 // RefreshValidatorInfos refreshes the info for the validator with the given operator address at the provided height
 func (m *Module) RefreshValidatorInfos(height int64, valOper string) error {
 	stakingValidator, err := m.source.GetValidator(height, valOper)

--- a/modules/upgrade/expected_modules.go
+++ b/modules/upgrade/expected_modules.go
@@ -1,0 +1,5 @@
+package upgrade
+
+type StakingModule interface {
+	RefreshAllValidatorInfos(height int64) error
+}

--- a/modules/upgrade/handle_block.go
+++ b/modules/upgrade/handle_block.go
@@ -1,0 +1,45 @@
+package upgrade
+
+import (
+	"fmt"
+
+	"github.com/forbole/juno/v3/types"
+
+	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
+)
+
+// HandleBlock implements modules.Module
+func (m *Module) HandleBlock(
+	b *tmctypes.ResultBlock, _ *tmctypes.ResultBlockResults, _ []*types.Tx, _ *tmctypes.ResultValidators,
+) error {
+	err := m.refreshDataUponSoftwareUpgrade(b.Block.Height)
+	if err != nil {
+		return fmt.Errorf("error while refreshing data upon software upgrade: %s", err)
+	}
+
+	return nil
+}
+
+func (m *Module) refreshDataUponSoftwareUpgrade(height int64) error {
+	exist, err := m.db.CheckSoftwareUpgradePlan(height)
+	if err != nil {
+		return fmt.Errorf("error while checking software upgrade plan existence: %s", err)
+	}
+	if !exist {
+		return nil
+	}
+
+	// Refresh validator infos
+	err = m.stakingModule.RefreshAllValidatorInfos(height)
+	if err != nil {
+		return fmt.Errorf("error while refreshing validator infos upon software upgrade: %s", err)
+	}
+
+	// Delete plan after refreshing data
+	err = m.db.TruncateSoftwareUpgradePlan(height)
+	if err != nil {
+		return fmt.Errorf("error while truncating software upgrade plan: %s", err)
+	}
+
+	return nil
+}

--- a/modules/upgrade/module.go
+++ b/modules/upgrade/module.go
@@ -1,0 +1,31 @@
+package upgrade
+
+import (
+	"github.com/forbole/bdjuno/v3/database"
+
+	"github.com/forbole/juno/v3/modules"
+)
+
+var (
+	_ modules.Module      = &Module{}
+	_ modules.BlockModule = &Module{}
+)
+
+// Module represents the x/upgrade module
+type Module struct {
+	db            *database.Db
+	stakingModule StakingModule
+}
+
+// NewModule builds a new Module instance
+func NewModule(db *database.Db, stakingModule StakingModule) *Module {
+	return &Module{
+		stakingModule: stakingModule,
+		db:            db,
+	}
+}
+
+// Name implements modules.Module
+func (m *Module) Name() string {
+	return "upgrade"
+}


### PR DESCRIPTION
…(#467)

Closes: #XXXX

jira: https://forbole.atlassian.net/browse/BDU-604

Background:
Sifchain hard-coded `validator minimum commission` in a new release and updated it with `software upgrade`. Without any `MsgEditValidator` involved, the `validator commission %` could not be updated and were then incorrect.

This PR stores `software upgrade proposal's upgrade plan` and uses the `upgrade` module to check if there's an upgrade plan at each height, if yes it will proceed with neccessary updates of data. Currently it's only updating the validator infos (the rest of the data I believe we have `periodic task` or `handle block` which should be enough). We can add more  in the future if similar cases pop up.