### PR TITLE
fix: Custom message parsing

### DIFF
--- a/cmd/bdjuno/cheqd.go
+++ b/cmd/bdjuno/cheqd.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	didMsgs "github.com/cheqd/cheqd-node/x/cheqd/types"
+	resourceMsgs "github.com/cheqd/cheqd-node/x/resource/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/forbole/juno/v3/modules/messages"
+)
+
+// CheqdAddressesParser represents a MessageAddressesParser for the my custom module
+// here, we're using a DID as the address
+func CheqdAddressesParser(_ codec.Codec, cosmosMsg sdk.Msg) ([]string, error) {
+	switch msg := cosmosMsg.(type) {
+
+	case *didMsgs.MsgCreateDid:
+		return []string{msg.GetPayload().GetId()}, nil
+
+	case *didMsgs.MsgUpdateDid:
+		return []string{msg.GetPayload().GetId()}, nil
+
+	case *resourceMsgs.MsgCreateResource:
+		return []string{msg.GetPayload().GetId()}, nil
+
+	default:
+		return nil, messages.MessageNotSupported(cosmosMsg)
+	}
+}

--- a/cmd/bdjuno/main.go
+++ b/cmd/bdjuno/main.go
@@ -66,6 +66,9 @@ func getBasicManagers() []module.BasicManager {
 // This should be edited by custom implementations if needed.
 func getAddressesParser() messages.MessageAddressesParser {
 	return messages.JoinMessageParsers(
+		// this is needed so that bdjuno can parse our custom messages properly
+		// https://docs.bigdipper.live/cosmos-based/parser/custom-chains#optional-add-your-custom-addresses-parser
+		CheqdAddressesParser,
 		messages.CosmosMessageAddressesParser,
 	)
 }


### PR DESCRIPTION
This PR attempts to fix the custom message parsing. With out current deployment of bdjuno, transactions are being parse correctly and stored in the database. However, bdjuno fails to insert any custom message records into `message` table. Built-in Cosmos messages seems to cause no errors.

Error Message: BDJuno Service
```json
{
  "level":"error",
  "err":"message type not supported: cheqdid.cheqdnode.cheqd.v1.MsgUpdateDid",
  "height":3857376,
  "module":"messages",
  "msg_type":"cheqdid.cheqdnode.cheqd.v1.MsgUpdateDid",
  "tx_hash":"850B295DD075539CD255601D6D412B538363A845746366663DF44DF9FFDC1741",
  "time":"2022-10-20T09:47:58Z",
  "message":"error while handling message"
}
```


I suspect that this error is related to missing [CustomAddressesParser](https://docs.bigdipper.live/cosmos-based/parser/custom-chains#optional-add-your-custom-addresses-parser) function.

The error thrown by the service matches a case here https://github.com/forbole/juno/blob/cosmos/v0.44.x/modules/messages/account_parser.go#L24

And by connecting all of this together, this error is thrown when we don't add a custom address parser