### PR TITLE
fix: Populate tx logs from tx events [DEV-5664]

### DIFF
--- a/juno-fork/node/local/utils.go
+++ b/juno-fork/node/local/utils.go
@@ -56,6 +56,13 @@ func makeTxResult(txConfig client.TxConfig, resTx *tmctypes.ResultTx, resBlock *
 
 // NewTxResponseFromSdkTxResponse allows to build a new TxResponse instance from the given sdk.TxResponse
 func NewTxResponseFromSdkTxResponse(txResponse *sdk.TxResponse, tx *types.Tx) *types.TxResponse {
+	// In Cosmos SDK v0.50.x, the Logs field is no longer populated.
+	// Events now contain a msg_index attribute to correlate with messages.
+	// We need to convert Events to Logs format for backward compatibility.
+	if len(txResponse.Logs) == 0 && len(txResponse.Events) > 0 {
+		txResponse.Logs = types.EventsToLogs(sdk.StringifyEvents(txResponse.Events))
+	}
+
 	return &types.TxResponse{
 		TxResponse: txResponse,
 		Tx:         tx,

--- a/juno-fork/node/remote/node.go
+++ b/juno-fork/node/remote/node.go
@@ -22,6 +22,7 @@ import (
 	httpclient "github.com/cometbft/cometbft/rpc/client/http"
 	tmctypes "github.com/cometbft/cometbft/rpc/core/types"
 	jsonrpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var (
@@ -209,6 +210,13 @@ func (cp *Node) Tx(hash string) (*types.Transaction, error) {
 	err = json.Unmarshal(body, &convTx)
 	if err != nil {
 		return nil, fmt.Errorf("error converting transaction: %s", err.Error())
+	}
+
+	// Convert Events to Logs for SDK v0.50.x compatibility
+	if convTx.TxResponse != nil && convTx.TxResponse.TxResponse != nil {
+		if len(convTx.TxResponse.Logs) == 0 && len(convTx.TxResponse.Events) > 0 {
+			convTx.TxResponse.Logs = types.EventsToLogs(sdk.StringifyEvents(convTx.TxResponse.Events))
+		}
 	}
 
 	return convTx, nil

--- a/juno-fork/types/cosmos.go
+++ b/juno-fork/types/cosmos.go
@@ -3,8 +3,10 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
+	abci "github.com/cometbft/cometbft/abci/types"
 	tmctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 
@@ -107,13 +109,43 @@ func NewTransaction(txResponse *TxResponse, tx *Tx) (*Transaction, error) {
 // to find the event having the given type, and returns it.
 // If no such event is found, returns an error instead.
 func (tx Transaction) FindEventByType(index int, eventType string) (sdk.StringEvent, error) {
-	for _, ev := range tx.Logs[index].Events {
-		if ev.Type == eventType {
-			return ev, nil
+	// In SDK v0.50.x, Logs is empty but Events contains data with msg_index attribute
+	if len(tx.Logs) > index {
+		for _, ev := range tx.Logs[index].Events {
+			if ev.Type == eventType {
+				return ev, nil
+			}
+		}
+	} else if tx.TxResponse != nil && len(tx.Events) > 0 {
+		// Fallback to Events for SDK v0.50.x compatibility
+		for _, ev := range tx.Events {
+			// Check if this event belongs to the specified message index
+			for _, attr := range ev.Attributes {
+				if attr.Key == "msg_index" {
+					if idx, err := strconv.Atoi(attr.Value); err == nil && idx == index {
+						if ev.Type == eventType {
+							return sdk.StringEvent{
+								Type:       ev.Type,
+								Attributes: stringifyAttributes(ev.Attributes),
+							}, nil
+						}
+					}
+					break
+				}
+			}
 		}
 	}
 
 	return sdk.StringEvent{}, fmt.Errorf("no %s event found inside tx with hash %s", eventType, tx.TxHash)
+}
+
+// stringifyAttributes converts abci.EventAttribute to sdk.Attribute
+func stringifyAttributes(attrs []abci.EventAttribute) []sdk.Attribute {
+	result := make([]sdk.Attribute, len(attrs))
+	for i, attr := range attrs {
+		result[i] = sdk.Attribute{Key: attr.Key, Value: attr.Value}
+	}
+	return result
 }
 
 // FindAttributeByKey searches inside the specified event of the given tx to find the attribute having the given key.
@@ -144,6 +176,48 @@ type TxResponse struct {
 	Height    uint64 `json:"height,string,omitempty"`
 	GasWanted uint64 `json:"gas_wanted,string,omitempty"`
 	GasUsed   uint64 `json:"gas_used,string,omitempty"`
+}
+
+// EventsToLogs converts a slice of ABCI events to ABCIMessageLogs by grouping events by msg_index.
+// This is needed for Cosmos SDK v0.50.x compatibility where Logs are no longer populated.
+func EventsToLogs(events []sdk.StringEvent) sdk.ABCIMessageLogs {
+	// Group events by msg_index
+	eventsByMsgIndex := make(map[int][]sdk.StringEvent)
+	maxMsgIndex := -1
+
+	for _, event := range events {
+		msgIndex := 0
+		for _, attr := range event.Attributes {
+			if attr.Key == "msg_index" {
+				if idx, err := strconv.Atoi(attr.Value); err == nil {
+					msgIndex = idx
+				}
+				break
+			}
+		}
+
+		if msgIndex > maxMsgIndex {
+			maxMsgIndex = msgIndex
+		}
+
+		eventsByMsgIndex[msgIndex] = append(eventsByMsgIndex[msgIndex], event)
+	}
+
+	// Handle case where no events have msg_index (all events go to index 0)
+	if maxMsgIndex < 0 {
+		maxMsgIndex = 0
+	}
+
+	// Create ABCIMessageLogs from grouped events
+	logs := make(sdk.ABCIMessageLogs, maxMsgIndex+1)
+	for i := 0; i <= maxMsgIndex; i++ {
+		logs[i] = sdk.ABCIMessageLog{
+			MsgIndex: uint32(i),
+			Events:   eventsByMsgIndex[i],
+		}
+	}
+
+	return logs
 }
 
 // -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Since the bump to the Cosmos SDK v0.50.x, the transactions don't populate logs anymore:

- https://rpc.cheqd.network/tx?hash=0x40A3BBE6E20A10A24F1A0724FFA02869BB363F10BAAEDA78B7376B065FDDEEE0 [post upgrade]
- https://rpc.cheqd.network/tx?hash=0xBC2069AB572FA409A2AC3A382E0D1EDFB4A5614CDBE0E82395B18D9F58AA6EE8 [pre upgrade]

This caused some inconsistencies on our explorer FE, like displaying the amount of withdrawn CHEQ tokens (always 0).

We added a custom function to fetch these from `.result.tx_result.events` field and populate them into `transaction.logs` column in our database.

Here's a quick example (logs were manually populated into the testnet DB), which confirms the hypothesis - https://testnet-explorer.cheqd.io/transactions/40A3BBE6E20A10A24F1A0724FFA02869BB363F10BAAEDA78B7376B065FDDEEE0.
You can see that the token amount is properly displayed, unlike in some previous transactions.